### PR TITLE
Removing Drupal Core. It is unnecessarily downloaded.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,16 +20,10 @@
       "email": "luke@fourkitchens.com"
     }
   ],
-  "repositories": [
-    {
-      "type": "composer",
-      "url": "https://packages.drupal.org/8"
-    }
-  ],
+  "repositories": [],
   "require": {},
   "require-dev": {
-    "drupal/coder": "2.7",
-    "squizlabs/PHP_CodeSniffer": "~2.0"
+    "drupal/coder": "8.2.7"
   },
   "conflict": {},
   "minimum-stability": "dev",
@@ -39,9 +33,5 @@
   "config": {
     "sort-packages": "true"
   },
-  "extra": {
-    "installer-paths": {
-      "vendor/drupal/{$name}": ["type:drupal-core", "type:drupal-module"]
-    }
-  }
+  "extra": {}
 }

--- a/gulp-tasks/phpcs.js
+++ b/gulp-tasks/phpcs.js
@@ -109,12 +109,6 @@
     gulp.task('install-phpcs', 'Install phpcs and dependencies using Composer.', function () {
       // Run composer install inside this module.
       execSync('composer install -d ' + path.join(__dirname, '../'), {stdio: 'inherit'});
-
-      // The composer install will download Drupal core, which we don't actually
-      // need. Remove it.
-      if (fs.existsSync(path.join(__dirname, '/../vendor/drupal/core'))) {
-        fs.removeSync(path.join(__dirname, '/../vendor/drupal/core'));
-      }
     });
 
   };


### PR DESCRIPTION
drupal/coder is provided by packagist. That version of it doesn't inject the drupal core requirement.

FYI, if you need to ever install this version in addition to the drupal version... see https://stackoverflow.com/questions/29400088/how-do-i-use-a-package-in-composer-that-has-the-same-name-as-another-package